### PR TITLE
Remove VRF from static route prerequisites

### DIFF
--- a/netbox_routing/models/static.py
+++ b/netbox_routing/models/static.py
@@ -51,10 +51,7 @@ class StaticRoute(PrimaryModel):
     clone_fields = (
         'vrf', 'metric', 'permanent'
     )
-    prerequisite_models = (
-        'dcim.Device',
-        'ipam.VRF',
-    )
+    prerequisite_models = ('dcim.Device',)
 
     class Meta:
         ordering = ['vrf', 'prefix', 'metric']


### PR DESCRIPTION
The VRF field is optional for the StaticRoute model. Therefore, no warning should be displayed if the user does not have any VRFs configured or does not want to use them in static routes.