### PR TITLE
Remove card-body container

### DIFF
--- a/netbox_routing/templates/netbox_routing/bgpaddressfamily.html
+++ b/netbox_routing/templates/netbox_routing/bgpaddressfamily.html
@@ -8,22 +8,20 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">BGP Address Family</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Scope</th>
-            <td>
-              {{ object.scope|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Address Family</th>
-            <td>
-              {{ object.address_family }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Scope</th>
+          <td>
+            {{ object.scope|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Address Family</th>
+          <td>
+            {{ object.address_family }}
+          </td>
+        </tr>
+      </table>
     </div>
     {% include 'netbox_routing/inc/settings.html' %}
     {% plugin_left_page object %}

--- a/netbox_routing/templates/netbox_routing/bgprouter.html
+++ b/netbox_routing/templates/netbox_routing/bgprouter.html
@@ -8,22 +8,20 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">BGP Router</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Device</th>
-            <td>
-              {{ object.device|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">AS Number</th>
-            <td>
-              {{ object.asn|linkify }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Device</th>
+          <td>
+            {{ object.device|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">AS Number</th>
+          <td>
+            {{ object.asn|linkify }}
+          </td>
+        </tr>
+      </table>
     </div>
     {% include 'netbox_routing/inc/settings.html' %}
     {% plugin_left_page object %}

--- a/netbox_routing/templates/netbox_routing/bgpscope.html
+++ b/netbox_routing/templates/netbox_routing/bgpscope.html
@@ -8,22 +8,20 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">BGP Scope</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Router</th>
-            <td>
-              {{ object.router|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">AS Number</th>
-            <td>
-              {{ object.vrf|linkify }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Router</th>
+          <td>
+            {{ object.router|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">AS Number</th>
+          <td>
+            {{ object.vrf|linkify }}
+          </td>
+        </tr>
+      </table>
     </div>
     {% include 'netbox_routing/inc/settings.html' %}
     {% plugin_left_page object %}

--- a/netbox_routing/templates/netbox_routing/eigrpaddressfamily.html
+++ b/netbox_routing/templates/netbox_routing/eigrpaddressfamily.html
@@ -8,34 +8,32 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">EIGRP Details</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Router</th>
-            <td>
-              {{ object.router }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">VRF</th>
-            <td>
-              {{ object.vrf }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Family</th>
-            <td>
-              {{ object.family }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Router ID</th>
-            <td>
-              {% if object.rid %}{{ object.rid }}{% else %}{{ object.router.rid}}{% endif %}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Router</th>
+          <td>
+            {{ object.router }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">VRF</th>
+          <td>
+            {{ object.vrf }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Family</th>
+          <td>
+            {{ object.family }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Router ID</th>
+          <td>
+            {% if object.rid %}{{ object.rid }}{% else %}{{ object.router.rid}}{% endif %}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/eigrpinterface.html
+++ b/netbox_routing/templates/netbox_routing/eigrpinterface.html
@@ -8,59 +8,55 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header"></h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Router</th>
-            <td>
-              {{ object.router|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Address Family</th>
-            <td>
-              {{ object.address_family|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Interface</th>
-            <td>
-              {{ object.interface|linkify }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Router</th>
+          <td>
+            {{ object.router|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Address Family</th>
+          <td>
+            {{ object.address_family|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Interface</th>
+          <td>
+            {{ object.interface|linkify }}
+          </td>
+        </tr>
+      </table>
     </div>
     <div class="card">
       <h5 class="card-header">Attributes</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Passive</th>
-            <td>
-              {{ object.passive|placeholder }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">BFD</th>
-            <td>
-              {{ object.bfd|placeholder }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Authentication Type</th>
-            <td>
-              {{ object.authentication|placeholder }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Passphrase (or keyring)</th>
-            <td>
-              {{ object.passphrase|placeholder }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Passive</th>
+          <td>
+            {{ object.passive|placeholder }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">BFD</th>
+          <td>
+            {{ object.bfd|placeholder }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Authentication Type</th>
+          <td>
+            {{ object.authentication|placeholder }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Passphrase (or keyring)</th>
+          <td>
+            {{ object.passphrase|placeholder }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/eigrpnetwork.html
+++ b/netbox_routing/templates/netbox_routing/eigrpnetwork.html
@@ -8,28 +8,26 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header"></h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Router</th>
-            <td>
-              {{ object.router|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Address Family</th>
-            <td>
-              {{ object.address_family|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Network</th>
-            <td>
-              {{ object.network|linkify }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Router</th>
+          <td>
+            {{ object.router|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Address Family</th>
+          <td>
+            {{ object.address_family|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Network</th>
+          <td>
+            {{ object.network|linkify }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/eigrprouter.html
+++ b/netbox_routing/templates/netbox_routing/eigrprouter.html
@@ -8,34 +8,32 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">EIGRP Details</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Device</th>
-            <td>
-              {{ object.device|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Router ID</th>
-            <td>
-              {{ object.rid }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Name</th>
-            <td>
-              {{ object.name }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Process ID</th>
-            <td>
-              {{ object.process_id }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Device</th>
+          <td>
+            {{ object.device|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Router ID</th>
+          <td>
+            {{ object.rid }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Name</th>
+          <td>
+            {{ object.name }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Process ID</th>
+          <td>
+            {{ object.process_id }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/inc/settings.html
+++ b/netbox_routing/templates/netbox_routing/inc/settings.html
@@ -1,15 +1,13 @@
     <div class="card">
       <h5 class="card-header">Settings</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          {% for setting in object.settings.all %}
-            <tr>
-              <th scope="row">{{ setting.get_key_display }}</th>
-              <td>
-                {{ setting.value }}
-              </td>
-            </tr>
-          {% endfor %}
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        {% for setting in object.settings.all %}
+          <tr>
+            <th scope="row">{{ setting.get_key_display }}</th>
+            <td>
+              {{ setting.value }}
+            </td>
+          </tr>
+        {% endfor %}
+      </table>
     </div>

--- a/netbox_routing/templates/netbox_routing/ospfinstance.html
+++ b/netbox_routing/templates/netbox_routing/ospfinstance.html
@@ -8,40 +8,38 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">OSPF Details</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Name</th>
-            <td>
-              {{ object.name }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Router ID</th>
-            <td>
-              {{ object.router_id }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Process ID</th>
-            <td>
-              {{ object.process_id }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Device</th>
-            <td>
-              {{ object.device|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">VRF</th>
-            <td>
-              {{ object.vrf|linkify }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Name</th>
+          <td>
+            {{ object.name }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Router ID</th>
+          <td>
+            {{ object.router_id }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Process ID</th>
+          <td>
+            {{ object.process_id }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Device</th>
+          <td>
+            {{ object.device|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">VRF</th>
+          <td>
+            {{ object.vrf|linkify }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/ospfinterface.html
+++ b/netbox_routing/templates/netbox_routing/ospfinterface.html
@@ -8,65 +8,61 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header"></h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Instance</th>
-            <td>
-              {{ object.instance|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Area</th>
-            <td>
-              {{ object.area|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Interface</th>
-            <td>
-              {{ object.interface|linkify }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Instance</th>
+          <td>
+            {{ object.instance|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Area</th>
+          <td>
+            {{ object.area|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Interface</th>
+          <td>
+            {{ object.interface|linkify }}
+          </td>
+        </tr>
+      </table>
     </div>
     <div class="card">
       <h5 class="card-header">Attributes</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Passive</th>
-            <td>
-              {{ object.passive|placeholder }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">BFD</th>
-            <td>
-              {{ object.bfd|placeholder }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Priority</th>
-            <td>
-              {{ object.priority|placeholder }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Authentication Type</th>
-            <td>
-              {{ object.authentication|placeholder }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Passphrase (or keyring)</th>
-            <td>
-              {{ object.passphrase|placeholder }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Passive</th>
+          <td>
+            {{ object.passive|placeholder }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">BFD</th>
+          <td>
+            {{ object.bfd|placeholder }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Priority</th>
+          <td>
+            {{ object.priority|placeholder }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Authentication Type</th>
+          <td>
+            {{ object.authentication|placeholder }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Passphrase (or keyring)</th>
+          <td>
+            {{ object.passphrase|placeholder }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/prefixlist.html
+++ b/netbox_routing/templates/netbox_routing/prefixlist.html
@@ -8,16 +8,14 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">Static Route</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Name</th>
-            <td>
-              {{ object.name }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Name</th>
+          <td>
+            {{ object.name }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/prefixlistentry.html
+++ b/netbox_routing/templates/netbox_routing/prefixlistentry.html
@@ -8,46 +8,44 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">Prefix List Entry</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Prefix List</th>
-            <td>
-              {{ object.prefix_list|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Sequence</th>
-            <td>
-              {{ object.sequence }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Type</th>
-            <td>
-              {% badge object.get_type_display bg_color=object.get_type_color %}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Prefix</th>
-            <td>
-              {{ object.prefix|placeholder }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">GE</th>
-            <td>
-              {{ object.ge }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">LE</th>
-            <td>
-              {{ object.le }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Prefix List</th>
+          <td>
+            {{ object.prefix_list|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Sequence</th>
+          <td>
+            {{ object.sequence }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Type</th>
+          <td>
+            {% badge object.get_type_display bg_color=object.get_type_color %}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Prefix</th>
+          <td>
+            {{ object.prefix|placeholder }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">GE</th>
+          <td>
+            {{ object.ge }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">LE</th>
+          <td>
+            {{ object.le }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/routemap.html
+++ b/netbox_routing/templates/netbox_routing/routemap.html
@@ -8,16 +8,14 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">Static Route</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Name</th>
-            <td>
-              {{ object.name }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Name</th>
+          <td>
+            {{ object.name }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/routemapentry.html
+++ b/netbox_routing/templates/netbox_routing/routemapentry.html
@@ -8,28 +8,26 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">Route Map Entry</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Route Map</th>
-            <td>
-              {{ object.route_map|linkify }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Type</th>
-            <td>
-              {% badge object.get_type_display bg_color=object.get_type_color %}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Sequence</th>
-            <td>
-              {{ object.sequence }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Route Map</th>
+          <td>
+            {{ object.route_map|linkify }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Type</th>
+          <td>
+            {% badge object.get_type_display bg_color=object.get_type_color %}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Sequence</th>
+          <td>
+            {{ object.sequence }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>

--- a/netbox_routing/templates/netbox_routing/staticroute.html
+++ b/netbox_routing/templates/netbox_routing/staticroute.html
@@ -8,75 +8,71 @@
   <div class="col col-md-6">
     <div class="card">
       <h5 class="card-header">Details</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">Name</th>
-            <td>
-              {{object.name}}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Description</th>
-            <td>
-              {{object.description}}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">Name</th>
+          <td>
+            {{object.name}}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Description</th>
+          <td>
+            {{object.description}}
+          </td>
+        </tr>
+      </table>
     </div>
     <div class="card">
       <h5 class="card-header">Static Route</h5>
-      <div class="card-body">
-        <table class="table table-hover attr-table">
-          <tr>
-            <th scope="row">VRF</th>
-            <td>
-              {% if object.vrf %}
-                <a href="{% url 'ipam:vrf' pk=object.vrf.pk %}">{{ object.vrf }}</a>
-              {% else %}
-                <span>Global</span>
-              {% endif %}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Prefix</th>
-            <td>
-              {{ object.prefix }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Next Hop</th>
-            <td>
-              {{ object.next_hop }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Name</th>
-            <td>
-              {{ object.name|placeholder }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Metric</th>
-            <td>
-              {{ object.metric }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Permanent</th>
-            <td>
-              {{ object.permanent }}
-            </td>
-          </tr>
-          <tr>
-            <th scope="row">Route Tag</th>
-            <td>
-              {{ object.tag }}
-            </td>
-          </tr>
-        </table>
-      </div>
+      <table class="table table-hover attr-table">
+        <tr>
+          <th scope="row">VRF</th>
+          <td>
+            {% if object.vrf %}
+              <a href="{% url 'ipam:vrf' pk=object.vrf.pk %}">{{ object.vrf }}</a>
+            {% else %}
+              <span>Global</span>
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Prefix</th>
+          <td>
+            {{ object.prefix }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Next Hop</th>
+          <td>
+            {{ object.next_hop }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Name</th>
+          <td>
+            {{ object.name|placeholder }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Metric</th>
+          <td>
+            {{ object.metric }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Permanent</th>
+          <td>
+            {{ object.permanent }}
+          </td>
+        </tr>
+        <tr>
+          <th scope="row">Route Tag</th>
+          <td>
+            {{ object.tag }}
+          </td>
+        </tr>
+      </table>
     </div>
       {% plugin_left_page object %}
   </div>


### PR DESCRIPTION
Starting with NetBox v4.0, the `card-body` container is no longer required for tables. This change ensures consistency with the updated NetBox v4 design and eliminates unnecessary whitespace.