### PR TITLE
Fixes #139: Correct BGPRouterForm peer_templates label

### DIFF
--- a/netbox_routing/forms/model_objects/bgp.py
+++ b/netbox_routing/forms/model_objects/bgp.py
@@ -459,7 +459,7 @@ class BGPRouterForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
         queryset=BGPPeerTemplate.objects.all(),
         required=False,
         selector=False,
-        label=_('Session Templates'),
+        label=_('Peer Templates'),
     )
 
     fieldsets = [


### PR DESCRIPTION
Fixes #139: Corrected the label of the peer_templates field under BGPRouterForm