### PR TITLE
FIX: prefixlen lookup for PrefixListEntry

### DIFF
--- a/netbox_routing/models/objects.py
+++ b/netbox_routing/models/objects.py
@@ -188,12 +188,12 @@ class PrefixListEntry(PermitDenyChoiceMixin, PrimaryModel):
                     }
                 )
 
-            if self.ge is not None and self.prefix.prefix.prefixlen >= self.ge:
+            if self.ge is not None and self.prefix.prefixlen >= self.ge:
                 raise ValidationError(
                     'Prefix\'s length cannot be longer then greater or equals value'
                 )
 
-            if self.le is not None and self.prefix.prefix.prefixlen >= self.le:
+            if self.le is not None and self.prefix.prefixlen >= self.le:
                 raise ValidationError(
                     'Prefix\'s length cannot be longer then greater or equals value'
                 )


### PR DESCRIPTION
The current code fails with `Exception Value: 'IPNetwork' object has no attribute 'prefix'`.
I've tested the fix locally.