### PR TITLE
Fixes: #153 - remove 'device' from OSPFInterface model clone_fields.

### DIFF
--- a/netbox_routing/models/ospf.py
+++ b/netbox_routing/models/ospf.py
@@ -122,7 +122,6 @@ class OSPFInterface(PrimaryModel):
     passphrase = models.CharField(max_length=200, blank=True, null=True)
 
     clone_fields = (
-        'device',
         'instance',
         'area',
         'interface',


### PR DESCRIPTION
Fixes #153

OSPFInterface does not have direct relationship to device, so `clone_fields` caused Django's `get_field()` to raise `FieldDoesNotExist` when rendering the detail view.