### PR TITLE
Fix standard PrimaryModel fields missing from BGP, OSPF, EIGRP, and Static forms

### DIFF
--- a/netbox_routing/filtersets/community.py
+++ b/netbox_routing/filtersets/community.py
@@ -53,7 +53,7 @@ class CommunityFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        qs_filter = Q(community__icontains=value)
+        qs_filter = Q(community__icontains=value) | Q(description__icontains=value)
         return queryset.filter(qs_filter).distinct()
 
 
@@ -72,7 +72,7 @@ class CommunityListFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        qs_filter = Q(name__icontains=value)
+        qs_filter = Q(name__icontains=value) | Q(description__icontains=value)
         return queryset.filter(qs_filter).distinct()
 
 
@@ -115,4 +115,5 @@ class CommunityListEntryFilterSet(NetBoxModelFilterSet):
             return queryset
         qs_filter = Q(community_list__name__icontains=value)
         qs_filter |= Q(community__community__icontains=value)
+        qs_filter |= Q(description__icontains=value)
         return queryset.filter(qs_filter).distinct()

--- a/netbox_routing/forms/model_objects/bgp.py
+++ b/netbox_routing/forms/model_objects/bgp.py
@@ -211,6 +211,8 @@ class BGPSettingForm(PrimaryModelForm):
             'addressfamily',
             'key',
             'value',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -262,7 +264,7 @@ class BGPPeerTemplateForm(TenancyForm, PrimaryModelForm):
     )
 
     fieldsets = (
-        FieldSet('name', 'remote_as', 'enabled'),
+        FieldSet('name', 'remote_as', 'enabled', 'description'),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
 
@@ -273,6 +275,8 @@ class BGPPeerTemplateForm(TenancyForm, PrimaryModelForm):
             'remote_as',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -314,6 +318,7 @@ class BGPPolicyTemplateForm(TenancyForm, PrimaryModelForm):
         FieldSet(
             'name',
             'parents',
+            'description',
         ),
         FieldSet(
             'prefixlist_out',
@@ -336,6 +341,8 @@ class BGPPolicyTemplateForm(TenancyForm, PrimaryModelForm):
             'routemap_in',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -367,6 +374,7 @@ class BGPSessionTemplateForm(TenancyForm, PrimaryModelForm):
             'parent',
             'remote_as',
             'local_as',
+            'description',
         ),
         FieldSet('pasword', 'bfd', 'ttl', 'enabled', name=_('Setings')),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
@@ -385,6 +393,8 @@ class BGPSessionTemplateForm(TenancyForm, PrimaryModelForm):
             'password',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -467,6 +477,7 @@ class BGPRouterForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
     fieldsets = [
         FieldSet(
             'name',
+            'description',
         ),
         FieldSet(
             TabbedGroups(
@@ -511,6 +522,8 @@ class BGPRouterForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
             'peer_templates',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -590,7 +603,7 @@ class BGPScopeForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
     )
 
     fieldsets = (
-        FieldSet('router', 'vrf', name=_('Scope')),
+        FieldSet('router', 'vrf', 'description', name=_('Scope')),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
 
@@ -601,6 +614,8 @@ class BGPScopeForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
             'vrf',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -623,7 +638,7 @@ class BGPAddressFamilyForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
     )
 
     fieldsets = (
-        FieldSet('scope', 'address_family', name=_('Address Family')),
+        FieldSet('scope', 'address_family', 'description', name=_('Address Family')),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
 
@@ -634,6 +649,8 @@ class BGPAddressFamilyForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
             'address_family',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -671,6 +688,7 @@ class BGPPeerForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
     fieldsets = (
         FieldSet(
             'name',
+            'description',
         ),
         FieldSet('scope', 'peer', 'status', name=_('Peer')),
         FieldSet('remote_as', 'local_as', name=_('ASNs')),
@@ -694,6 +712,8 @@ class BGPPeerForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
             'password',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -755,7 +775,7 @@ class BGPPeerAddressFamilyForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
             ),
             name=_('Assigned Object'),
         ),
-        FieldSet('address_family', 'enabled'),
+        FieldSet('address_family', 'enabled', 'description'),
         FieldSet(
             'route_map_in',
             'route_map_out',
@@ -779,6 +799,8 @@ class BGPPeerAddressFamilyForm(BGPSettingMixin, TenancyForm, PrimaryModelForm):
             'prefix_list_out',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]

--- a/netbox_routing/forms/model_objects/community.py
+++ b/netbox_routing/forms/model_objects/community.py
@@ -16,9 +16,7 @@ __all__ = (
 class CommunityListForm(TenancyForm, PrimaryModelForm):
 
     fieldsets = (
-        FieldSet(
-            'name',
-        ),
+        FieldSet('name', 'description'),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
 
@@ -28,6 +26,8 @@ class CommunityListForm(TenancyForm, PrimaryModelForm):
             'name',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -36,7 +36,7 @@ class CommunityListForm(TenancyForm, PrimaryModelForm):
 class CommunityForm(TenancyForm, PrimaryModelForm):
 
     fieldsets = (
-        FieldSet('community', 'status', 'role'),
+        FieldSet('community', 'status', 'role', 'description'),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
 
@@ -48,6 +48,8 @@ class CommunityForm(TenancyForm, PrimaryModelForm):
             'role',
             'tenant_group',
             'tenant',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]
@@ -55,7 +57,7 @@ class CommunityForm(TenancyForm, PrimaryModelForm):
 
 class CommunityListEntryForm(PrimaryModelForm):
 
-    fieldsets = (FieldSet('community_list', 'action', 'community'),)
+    fieldsets = (FieldSet('community_list', 'action', 'community', 'description'),)
 
     class Meta:
         model = CommunityListEntry
@@ -63,6 +65,8 @@ class CommunityListEntryForm(PrimaryModelForm):
             'community_list',
             'action',
             'community',
+            'description',
+            'comments',
             'tags',
             'owner',
         ]

--- a/netbox_routing/forms/model_objects/eigrp.py
+++ b/netbox_routing/forms/model_objects/eigrp.py
@@ -6,10 +6,10 @@ from django.utils.translation import gettext as _
 from dcim.models import Interface, Device
 from ipam.choices import IPAddressFamilyChoices
 from ipam.models import VRF, Prefix
-from netbox.forms import NetBoxModelForm
+from netbox.forms import PrimaryModelForm
 from netbox_routing.choices.eigrp import EIGRPRouterChoices
 from utilities.forms import BOOLEAN_WITH_BLANK_CHOICES, get_field_value
-from utilities.forms.fields import DynamicModelChoiceField, CommentField
+from utilities.forms.fields import DynamicModelChoiceField
 from utilities.forms.widgets import HTMXSelect
 
 from netbox_routing.models import *
@@ -22,14 +22,13 @@ __all__ = (
 )
 
 
-class EIGRPRouterForm(NetBoxModelForm):
+class EIGRPRouterForm(PrimaryModelForm):
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
         required=True,
         selector=True,
         label=_('Device'),
     )
-    comments = CommentField()
 
     class Meta:
         model = EIGRPRouter
@@ -41,6 +40,8 @@ class EIGRPRouterForm(NetBoxModelForm):
             'rid',
             'description',
             'comments',
+            'tags',
+            'owner',
         )
         widgets = {
             'mode': HTMXSelect(),
@@ -56,7 +57,7 @@ class EIGRPRouterForm(NetBoxModelForm):
             del self.fields['name']
 
 
-class EIGRPAddressFamilyForm(NetBoxModelForm):
+class EIGRPAddressFamilyForm(PrimaryModelForm):
     router = DynamicModelChoiceField(
         queryset=EIGRPRouter.objects.all(),
         required=True,
@@ -74,7 +75,6 @@ class EIGRPAddressFamilyForm(NetBoxModelForm):
         choices=IPAddressFamilyChoices,
         label=_('Family'),
     )
-    comments = CommentField()
 
     class Meta:
         model = EIGRPAddressFamily
@@ -85,10 +85,12 @@ class EIGRPAddressFamilyForm(NetBoxModelForm):
             'rid',
             'description',
             'comments',
+            'tags',
+            'owner',
         )
 
 
-class EIGRPNetworkForm(NetBoxModelForm):
+class EIGRPNetworkForm(PrimaryModelForm):
     router = DynamicModelChoiceField(
         queryset=EIGRPRouter.objects.all(),
         required=True,
@@ -107,7 +109,6 @@ class EIGRPNetworkForm(NetBoxModelForm):
         selector=True,
         label=_('Prefix'),
     )
-    comments = CommentField()
 
     class Meta:
         model = EIGRPNetwork
@@ -117,10 +118,12 @@ class EIGRPNetworkForm(NetBoxModelForm):
             'network',
             'description',
             'comments',
+            'tags',
+            'owner',
         )
 
 
-class EIGRPInterfaceForm(NetBoxModelForm):
+class EIGRPInterfaceForm(PrimaryModelForm):
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
         required=False,
@@ -159,7 +162,6 @@ class EIGRPInterfaceForm(NetBoxModelForm):
         label='Passive Interface',
         widget=forms.Select(choices=BOOLEAN_WITH_BLANK_CHOICES),
     )
-    comments = CommentField()
 
     class Meta:
         model = EIGRPInterface
@@ -174,6 +176,8 @@ class EIGRPInterfaceForm(NetBoxModelForm):
             'passphrase',
             'description',
             'comments',
+            'tags',
+            'owner',
         )
 
         widgets = {

--- a/netbox_routing/forms/model_objects/ospf.py
+++ b/netbox_routing/forms/model_objects/ospf.py
@@ -4,9 +4,9 @@ from django.utils.translation import gettext as _
 
 from dcim.models import Interface, Device
 from ipam.models import VRF
-from netbox.forms import NetBoxModelForm
+from netbox.forms import PrimaryModelForm
 from utilities.forms import BOOLEAN_WITH_BLANK_CHOICES
-from utilities.forms.fields import DynamicModelChoiceField, CommentField
+from utilities.forms.fields import DynamicModelChoiceField
 from utilities.forms.rendering import FieldSet
 
 from netbox_routing.models import OSPFArea, OSPFInstance, OSPFInterface
@@ -18,7 +18,7 @@ __all__ = (
 )
 
 
-class OSPFInstanceForm(NetBoxModelForm):
+class OSPFInstanceForm(PrimaryModelForm):
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
         required=True,
@@ -31,7 +31,6 @@ class OSPFInstanceForm(NetBoxModelForm):
         selector=True,
         label=_('VRF'),
     )
-    comments = CommentField()
 
     fieldsets = (
         FieldSet(
@@ -60,11 +59,12 @@ class OSPFInstanceForm(NetBoxModelForm):
             'vrf',
             'description',
             'comments',
+            'tags',
+            'owner',
         )
 
 
-class OSPFAreaForm(NetBoxModelForm):
-    comments = CommentField()
+class OSPFAreaForm(PrimaryModelForm):
 
     class Meta:
         model = OSPFArea
@@ -73,10 +73,12 @@ class OSPFAreaForm(NetBoxModelForm):
             'area_type',
             'description',
             'comments',
+            'tags',
+            'owner',
         )
 
 
-class OSPFInterfaceForm(NetBoxModelForm):
+class OSPFInterfaceForm(PrimaryModelForm):
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
         required=False,
@@ -107,7 +109,6 @@ class OSPFInterfaceForm(NetBoxModelForm):
             'device_id': '$device',
         },
     )
-    comments = CommentField()
 
     fieldsets = (
         FieldSet(
@@ -148,6 +149,8 @@ class OSPFInterfaceForm(NetBoxModelForm):
             'passphrase',
             'description',
             'comments',
+            'tags',
+            'owner',
         )
 
         widgets = {

--- a/netbox_routing/forms/model_objects/static.py
+++ b/netbox_routing/forms/model_objects/static.py
@@ -2,17 +2,16 @@ from django.utils.translation import gettext as _
 
 from dcim.models import Device
 from ipam.models import VRF
-from netbox.forms import NetBoxModelForm
+from netbox.forms import PrimaryModelForm
 from netbox_routing.models import StaticRoute
 from utilities.forms.fields import (
     DynamicModelChoiceField,
     DynamicModelMultipleChoiceField,
-    CommentField,
 )
 from utilities.forms.rendering import FieldSet
 
 
-class StaticRouteForm(NetBoxModelForm):
+class StaticRouteForm(PrimaryModelForm):
     devices = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         label=_('Devices'),
@@ -22,7 +21,6 @@ class StaticRouteForm(NetBoxModelForm):
         required=False,
         label=_('VRF'),
     )
-    comments = CommentField()
 
     fieldsets = (
         FieldSet(
@@ -60,6 +58,7 @@ class StaticRouteForm(NetBoxModelForm):
             'description',
             'comments',
             'tags',
+            'owner',
         )
 
     def __init__(self, data=None, instance=None, *args, **kwargs):

--- a/netbox_routing/tables/community.py
+++ b/netbox_routing/tables/community.py
@@ -14,7 +14,7 @@ from tenancy.tables import TenancyColumnsMixin
 
 
 class CommunityTable(TenancyColumnsMixin, NetBoxTable):
-    community = tables.Column(verbose_name=_('Name'), linkify=True)
+    community = tables.Column(verbose_name=_('Community'), linkify=True)
     role = tables.Column(verbose_name=_('Role'), linkify=True)
 
     class Meta(NetBoxTable.Meta):
@@ -25,6 +25,7 @@ class CommunityTable(TenancyColumnsMixin, NetBoxTable):
             'community',
             'role',
             'status',
+            'description',
             'tenant_group',
             'tenant',
         )
@@ -32,6 +33,8 @@ class CommunityTable(TenancyColumnsMixin, NetBoxTable):
             'pk',
             'id',
             'community',
+            'status',
+            'description',
         )
 
 
@@ -44,6 +47,7 @@ class CommunityListTable(TenancyColumnsMixin, NetBoxTable):
             'pk',
             'id',
             'name',
+            'description',
             'tenant_group',
             'tenant',
         )
@@ -51,6 +55,7 @@ class CommunityListTable(TenancyColumnsMixin, NetBoxTable):
             'pk',
             'id',
             'name',
+            'description',
         )
 
 
@@ -66,6 +71,7 @@ class CommunityListEntryTable(NetBoxTable):
             'community_list',
             'action',
             'community',
+            'description',
         )
         default_columns = (
             'pk',
@@ -73,4 +79,5 @@ class CommunityListEntryTable(NetBoxTable):
             'community_list',
             'action',
             'community',
+            'description',
         )

--- a/netbox_routing/templates/netbox_routing/community.html
+++ b/netbox_routing/templates/netbox_routing/community.html
@@ -24,9 +24,11 @@
           </tr>
           <tr>
             <th scope="row">Role</th>
-            <td>
-              {{ object.get_role_display }}
-            </td>
+            <td>{{ object.role|linkify|placeholder }}</td>
+          </tr>
+          <tr>
+            <th scope="row">Description</th>
+            <td>{{ object.description|placeholder }}</td>
           </tr>
         </table>
       </div>

--- a/netbox_routing/templates/netbox_routing/communitylist.html
+++ b/netbox_routing/templates/netbox_routing/communitylist.html
@@ -16,6 +16,10 @@
               {{ object.name }}
             </td>
           </tr>
+          <tr>
+            <th scope="row">Description</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
         </table>
       </div>
     </div> 

--- a/netbox_routing/templates/netbox_routing/communitylistentry.html
+++ b/netbox_routing/templates/netbox_routing/communitylistentry.html
@@ -28,6 +28,10 @@
               {{ object.community|linkify }}
             </td>
           </tr>
+          <tr>
+            <th scope="row">Description</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
         </table>
       </div>
     </div> 

--- a/netbox_routing/tests/community/test_forms.py
+++ b/netbox_routing/tests/community/test_forms.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from ipam.models import Role
 from tenancy.models import Tenant
 
 from netbox_routing.choices import ActionChoices
@@ -15,19 +16,22 @@ class CommunityTestCase(TestCase):
         cls.tenant = Tenant.objects.create(name='Tenant 1')
         cls.role = Role.objects.create(name='Role 1')
 
-    def test_community(self):
+    def test_community_with_description_and_comments(self):
         form = CommunityForm(
             data={
                 'community': '64512',
-                'role': self.role,
+                'role': self.role.pk,
                 'status': 'active',
-                'tenant': self.tenant,
-                'description': 'Description',
-                'comment': 'Comment',
+                'tenant': self.tenant.pk,
+                'description': 'Blackhole community',
+                'comments': 'Used for DDoS mitigation',
             }
         )
-        self.assertTrue(form.is_valid())
-        self.assertTrue(form.save())
+        self.assertTrue(form.is_valid(), form.errors)
+        instance = form.save()
+        instance.refresh_from_db()
+        self.assertEqual(instance.description, 'Blackhole community')
+        self.assertEqual(instance.comments, 'Used for DDoS mitigation')
 
     def test_community_minimal(self):
         form = CommunityForm(
@@ -36,7 +40,7 @@ class CommunityTestCase(TestCase):
                 'status': 'active',
             }
         )
-        self.assertTrue(form.is_valid())
+        self.assertTrue(form.is_valid(), form.errors)
         self.assertTrue(form.save())
 
     def test_form_invalid_community(self):
@@ -68,27 +72,29 @@ class CommunityListTestCase(TestCase):
     def setUpTestData(cls):
         cls.tenant = Tenant.objects.create(name='Tenant 1')
 
-    def test_community_list(self):
+    def test_community_list_with_description_and_comments(self):
         form = CommunityListForm(
             data={
                 'name': 'Community List 1',
-                'tenant': self.tenant,
-                'description': 'Description',
-                'comment': 'Comment',
+                'tenant': self.tenant.pk,
+                'description': 'Customer communities',
+                'comments': 'Managed by NOC team',
             }
         )
-        self.assertTrue(form.is_valid())
-        self.assertTrue(form.save())
+        self.assertTrue(form.is_valid(), form.errors)
+        instance = form.save()
+        instance.refresh_from_db()
+        self.assertEqual(instance.description, 'Customer communities')
+        self.assertEqual(instance.comments, 'Managed by NOC team')
 
     def test_form_invalid(self):
         form = CommunityListForm(
             data={
-                'tenant': self.tenant,
+                'tenant': self.tenant.pk,
             }
         )
         self.assertFalse(form.is_valid())
         with self.assertRaises(ValueError):
-            form.save()
             form.save()
 
 
@@ -109,18 +115,21 @@ class CommunityListEntryTestCase(TestCase):
             tenant=cls.tenant,
         )
 
-    def test_community_list_entry(self):
+    def test_community_list_entry_with_description_and_comments(self):
         form = CommunityListEntryForm(
             data={
                 'community_list': self.community_list.pk,
                 'community': self.community.pk,
                 'action': ActionChoices.PERMIT,
-                'description': 'Description',
-                'comment': 'Comment',
+                'description': 'Allow blackhole',
+                'comments': 'Required for DDoS policy',
             }
         )
-        self.assertTrue(form.is_valid())
-        self.assertTrue(form.save())
+        self.assertTrue(form.is_valid(), form.errors)
+        instance = form.save()
+        instance.refresh_from_db()
+        self.assertEqual(instance.description, 'Allow blackhole')
+        self.assertEqual(instance.comments, 'Required for DDoS policy')
 
     def test_form_invalid(self):
         form = CommunityListEntryForm(

--- a/netbox_routing/tests/community/test_views.py
+++ b/netbox_routing/tests/community/test_views.py
@@ -53,6 +53,8 @@ class CommunityTestCase(
         cls.form_data = {
             'community': '64515',
             'status': 'active',
+            'description': 'Test community description',
+            'comments': 'Test community comments',
         }
 
         cls.bulk_edit_data = {
@@ -97,6 +99,8 @@ class CommunityListTestCase(
 
         cls.form_data = {
             'name': 'Community List X',
+            'description': 'Test community list description',
+            'comments': 'Test community list comments',
         }
 
         cls.bulk_edit_data = {
@@ -189,6 +193,8 @@ class CommunityListEntryTestCase(
             'community_list': cls.community_lists[2].pk,
             'community': cls.communities[2].pk,
             'action': ActionChoices.PERMIT,
+            'description': 'Test entry description',
+            'comments': 'Test entry comments',
         }
 
         cls.bulk_edit_data = {

--- a/netbox_routing/tests/test_form_meta.py
+++ b/netbox_routing/tests/test_form_meta.py
@@ -1,0 +1,63 @@
+"""
+Introspection tests that verify every form for a PrimaryModel-based model
+includes the standard PrimaryModel fields in Meta.fields.
+
+This guards against the class of bug where fields like description, comments,
+tags, or owner exist on the model but are silently dropped on UI save because
+they were omitted from the form's Meta.fields list.
+"""
+
+from django.test import SimpleTestCase
+
+from netbox.models import PrimaryModel
+from netbox_routing.forms import model_objects
+
+STANDARD_PRIMARYMODEL_FIELDS = ('description', 'comments', 'tags', 'owner')
+
+
+def _iter_model_forms():
+    """Yield every ModelForm class declared in netbox_routing.forms.model_objects."""
+    from django.forms import ModelForm
+
+    seen = set()
+    for submodule_name in ('bgp', 'community', 'eigrp', 'objects', 'ospf', 'static'):
+        submodule = getattr(model_objects, submodule_name, None)
+        if submodule is None:
+            continue
+        for attr_name in dir(submodule):
+            attr = getattr(submodule, attr_name)
+            if (
+                isinstance(attr, type)
+                and issubclass(attr, ModelForm)
+                and attr is not ModelForm
+                and attr.__module__.startswith('netbox_routing.')
+                and attr not in seen
+            ):
+                seen.add(attr)
+                yield attr
+
+
+class PrimaryModelFormFieldsTestCase(SimpleTestCase):
+    """Every form whose model inherits from PrimaryModel must expose the
+    standard fields in Meta.fields."""
+
+    def test_all_primarymodel_forms_include_standard_fields(self):
+        missing = {}
+        for form_cls in _iter_model_forms():
+            model = getattr(getattr(form_cls, 'Meta', None), 'model', None)
+            if model is None or not issubclass(model, PrimaryModel):
+                continue
+            declared = set(form_cls.Meta.fields)
+            gaps = [f for f in STANDARD_PRIMARYMODEL_FIELDS if f not in declared]
+            if gaps:
+                missing[form_cls.__name__] = gaps
+        self.assertFalse(
+            missing,
+            msg=(
+                'Forms missing standard PrimaryModel fields in Meta.fields. '
+                'These fields will be silently dropped on UI save:\n'
+                + '\n'.join(
+                    f'  {name}: {fields}' for name, fields in sorted(missing.items())
+                )
+            ),
+        )


### PR DESCRIPTION
## Summary

Wires up `description`, `comments`, `tags`, and `owner` fields (already present on the underlying PrimaryModel) across all remaining forms in the plugin. Same class of bug fixed for community models in #168, but covering BGP, OSPF, EIGRP, and Static route forms.
- BGP forms: added `description` and `comments` to all 8 forms missing them (BGPRouter, BGPScope, BGPAddressFamily, BGPPeer, BGPPeerAddressFamily, BGPSessionTemplate, BGPPolicyTemplate, BGPPeerTemplate). Added `comments` to BGPSetting which already had description.
- OSPF forms: switched all 3 forms (OSPFInstance, OSPFArea, OSPFInterface) from NetBoxModelForm to PrimaryModelForm. Added `tags` and `owner` to Meta.fields. Removed manual `comments = CommentField()` declarations now provided by PrimaryModelForm.
- EIGRP forms: same treatment as OSPF for all 4 forms (EIGRPRouter, EIGRPAddressFamily, EIGRPNetwork, EIGRPInterface).
- StaticRouteForm: switched from NetBoxModelForm to PrimaryModelForm. Added `owner` to Meta.fields. Removed manual CommentField declaration.

## Tests

Added a single introspection test (`tests/test_form_meta.py`) that iterates over every ModelForm in `netbox_routing.forms.model_objects` and asserts that forms backed by PrimaryModel-derived models include `description`, `comments`, `tags`, and `owner` in `Meta.fields`. This catches the original class of bug (silent field drops) and any future regressions when new forms are added, without requiring per-form persistence tests.

This PR builds on #168 and should be merged after it.

Fixes #170