### PR TITLE
Closes: #167 - Add optional name field to Community model

### DIFF
--- a/netbox_routing/api/_serializers/community.py
+++ b/netbox_routing/api/_serializers/community.py
@@ -26,6 +26,7 @@ class CommunitySerializer(NetBoxModelSerializer):
             'url',
             'id',
             'display',
+            'name',
             'community',
             'role',
             'status',
@@ -33,7 +34,7 @@ class CommunitySerializer(NetBoxModelSerializer):
             'description',
             'comments',
         )
-        brief_fields = ('url', 'id', 'display', 'community', 'description')
+        brief_fields = ('url', 'id', 'display', 'name', 'community', 'description')
 
 
 class CommunityListSerializer(NetBoxModelSerializer):

--- a/netbox_routing/filtersets/community.py
+++ b/netbox_routing/filtersets/community.py
@@ -40,6 +40,7 @@ class CommunityFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
     class Meta:
         model = Community
         fields = (
+            'name',
             'community',
             'status',
             'role_id',
@@ -53,7 +54,11 @@ class CommunityFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        qs_filter = Q(community__icontains=value) | Q(description__icontains=value)
+        qs_filter = (
+            Q(name__icontains=value)
+            | Q(community__icontains=value)
+            | Q(description__icontains=value)
+        )
         return queryset.filter(qs_filter).distinct()
 
 

--- a/netbox_routing/forms/bulk_import/community.py
+++ b/netbox_routing/forms/bulk_import/community.py
@@ -31,6 +31,7 @@ class CommunityImportForm(NetBoxModelImportForm):
     class Meta:
         model = Community
         fields = (
+            'name',
             'community',
             'status',
             'role',

--- a/netbox_routing/forms/filtersets/community.py
+++ b/netbox_routing/forms/filtersets/community.py
@@ -36,7 +36,7 @@ class CommunityFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     model = Community
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('community', 'status', 'role_id', name=_('Community')),
+        FieldSet('name', 'community', 'status', 'role_id', name=_('Community')),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
     status = forms.ChoiceField(

--- a/netbox_routing/forms/model_objects/community.py
+++ b/netbox_routing/forms/model_objects/community.py
@@ -36,13 +36,14 @@ class CommunityListForm(TenancyForm, PrimaryModelForm):
 class CommunityForm(TenancyForm, PrimaryModelForm):
 
     fieldsets = (
-        FieldSet('community', 'status', 'role', 'description'),
+        FieldSet('name', 'community', 'status', 'role', 'description'),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
 
     class Meta:
         model = Community
         fields = [
+            'name',
             'community',
             'status',
             'role',

--- a/netbox_routing/migrations/0029_community_name.py
+++ b/netbox_routing/migrations/0029_community_name.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_routing', '0028_staticroute_interface_next_hop_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='community',
+            name='name',
+            field=models.CharField(blank=True, max_length=100),
+        ),
+    ]

--- a/netbox_routing/models/community.py
+++ b/netbox_routing/models/community.py
@@ -43,6 +43,11 @@ class CommunityList(PrimaryModel):
 
 
 class Community(PrimaryModel):
+    name = models.CharField(
+        verbose_name=_('Name'),
+        max_length=100,
+        blank=True,
+    )
     community = models.CharField(
         verbose_name=_('Community'),
         max_length=255,
@@ -83,6 +88,8 @@ class Community(PrimaryModel):
         ]
 
     def __str__(self):
+        if self.name:
+            return f'{self.name} ({self.community})'
         return f'{self.community}'
 
     def get_absolute_url(self):

--- a/netbox_routing/search/community.py
+++ b/netbox_routing/search/community.py
@@ -6,11 +6,12 @@ from netbox_routing.models.community import *
 class CommunityIndex(SearchIndex):
     model = Community
     fields = (
+        ('name', 100),
         ('community', 100),
         ('description', 4000),
         ('comments', 5000),
     )
-    display_attrs = ('community',)
+    display_attrs = ('name', 'community')
 
 
 @register_search

--- a/netbox_routing/tables/community.py
+++ b/netbox_routing/tables/community.py
@@ -14,6 +14,7 @@ from tenancy.tables import TenancyColumnsMixin
 
 
 class CommunityTable(TenancyColumnsMixin, NetBoxTable):
+    name = tables.Column(verbose_name=_('Name'), linkify=True)
     community = tables.Column(verbose_name=_('Community'), linkify=True)
     role = tables.Column(verbose_name=_('Role'), linkify=True)
 
@@ -22,6 +23,7 @@ class CommunityTable(TenancyColumnsMixin, NetBoxTable):
         fields = (
             'pk',
             'id',
+            'name',
             'community',
             'role',
             'status',
@@ -32,6 +34,7 @@ class CommunityTable(TenancyColumnsMixin, NetBoxTable):
         default_columns = (
             'pk',
             'id',
+            'name',
             'community',
             'status',
             'description',

--- a/netbox_routing/templates/netbox_routing/community.html
+++ b/netbox_routing/templates/netbox_routing/community.html
@@ -11,6 +11,10 @@
       <div class="card-body">
         <table class="table table-hover attr-table">
           <tr>
+            <th scope="row">Name</th>
+            <td>{{ object.name|placeholder }}</td>
+          </tr>
+          <tr>
             <th scope="row">Community</th>
             <td>
               {{ object.community }}

--- a/netbox_routing/tests/community/test_api.py
+++ b/netbox_routing/tests/community/test_api.py
@@ -19,6 +19,7 @@ class CommunityTestCase(APIViewTestCases.APIViewTestCase):
         'description',
         'display',
         'id',
+        'name',
         'url',
     ]
 

--- a/netbox_routing/tests/community/test_forms.py
+++ b/netbox_routing/tests/community/test_forms.py
@@ -33,6 +33,33 @@ class CommunityTestCase(TestCase):
         self.assertEqual(instance.description, 'Blackhole community')
         self.assertEqual(instance.comments, 'Used for DDoS mitigation')
 
+    def test_community_with_name(self):
+        form = CommunityForm(
+            data={
+                'name': 'blackhole',
+                'community': '65000:666',
+                'status': 'active',
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        instance = form.save()
+        instance.refresh_from_db()
+        self.assertEqual(instance.name, 'blackhole')
+        self.assertEqual(str(instance), 'blackhole (65000:666)')
+
+    def test_community_without_name(self):
+        form = CommunityForm(
+            data={
+                'community': '65000:100',
+                'status': 'active',
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+        instance = form.save()
+        instance.refresh_from_db()
+        self.assertEqual(instance.name, '')
+        self.assertEqual(str(instance), '65000:100')
+
     def test_community_minimal(self):
         form = CommunityForm(
             data={

--- a/netbox_routing/tests/community/test_models.py
+++ b/netbox_routing/tests/community/test_models.py
@@ -64,6 +64,30 @@ class CommunityTestCase(TestCase):
             community.full_clean()
             community.save()
 
+    def test_str_with_name(self):
+        role = Role.objects.get(name='Test Role')
+        community = Community(
+            name='blackhole',
+            community='65000:666',
+            status='active',
+            role=role,
+        )
+        community.full_clean()
+        community.save()
+        self.assertEqual(str(community), 'blackhole (65000:666)')
+
+    def test_str_without_name(self):
+        role = Role.objects.get(name='Test Role')
+        community = Community(
+            community='65000:100',
+            status='active',
+            role=role,
+        )
+        community.full_clean()
+        community.save()
+        self.assertEqual(community.name, '')
+        self.assertEqual(str(community), '65000:100')
+
     def test_unique_together(self):
 
         role = Role.objects.get(name='Test Role')


### PR DESCRIPTION
## Summary

- Adds an optional `name` field (CharField, blank=True, max_length=100) to the Community model
- Allows operators to assign human-readable labels to BGP communities (e.g. `blackhole`, `no-export`) alongside their numeric value
- When set, `__str__` returns `"name (community)"` (e.g. `"blackhole (65000:666)"`); when empty, falls back to just the community value
- Backwards compatible: existing communities without a name behave exactly as before

## Changes

- Model: new `name` field, updated `__str__`
- Migration 0029 (AddField, no data migration needed since field is blank=True)
- `CommunityForm`: added to fieldset and Meta.fields
- `CommunityImportForm`: added to CSV import fields
- `CommunityFilterSet`: added as filter and included in free-text search
- `CommunityFilterForm`: added to sidebar filter
- `CommunitySerializer`: exposed in fields and brief_fields
- `CommunityTable`: added as default column
- `CommunityIndex`: indexed in global search
- New row in detail view

## Tests

- `test_str_with_name`: verifies `__str__` formats as `"name (community)"` when name is set
- `test_str_without_name`: verifies `__str__` returns just the community value when name is empty (and that empty string is the default)
- `test_community_with_name`: form-level test verifying name persists through save
- `test_community_without_name`: form-level test verifying empty name still saves successfully


Fixes #167