### PR TITLE
Fixes: #178 - Replace deprecated 'check' argument with 'condition' in CheckConstraint usage

### DIFF
--- a/netbox_routing/migrations/0001_initial.py
+++ b/netbox_routing/migrations/0001_initial.py
@@ -215,7 +215,7 @@ class Migration(migrations.Migration):
         migrations.AddConstraint(
             model_name='staticroute',
             constraint=models.CheckConstraint(
-                check=models.Q(models.Q(('metric__lte', 255), ('metric__gte', 0))),
+                condition=models.Q(models.Q(('metric__lte', 255), ('metric__gte', 0))),
                 name='metric_gte_lte',
             ),
         ),

--- a/netbox_routing/models/static.py
+++ b/netbox_routing/models/static.py
@@ -76,7 +76,7 @@ class StaticRoute(PrimaryModel):
         ordering = ['vrf', 'prefix', 'metric']
         constraints = (
             CheckConstraint(
-                check=Q(Q(metric__lte=255) & Q(metric__gte=0)), name='metric_gte_lte'
+                condition=Q(Q(metric__lte=255) & Q(metric__gte=0)), name='metric_gte_lte'
             ),
             models.UniqueConstraint(
                 'vrf',


### PR DESCRIPTION
### Fixes: #178 - Replace deprecated 'check' argument with 'condition' in CheckConstraint usage

The 'check' argument in Django`s CheckConstraint is deprecated in favor of 'condition' since Django 5.1 and removed in 6.0. I updated all usage I could find to the new argument.
