### PR TITLE
feat: add route type for blackhole/unreachable static routes

### DIFF
--- a/netbox_routing/api/_serializers/static.py
+++ b/netbox_routing/api/_serializers/static.py
@@ -16,7 +16,7 @@ class StaticRouteSerializer(NetBoxModelSerializer):
     )
     devices = DeviceSerializer(many=True, nested=True, required=False, allow_null=True)
     vrf = VRFSerializer(nested=True, required=False, allow_null=True)
-    next_hop = IPAddressField()
+    next_hop = IPAddressField(required=False, allow_null=True)
 
     class Meta:
         model = StaticRoute
@@ -27,7 +27,9 @@ class StaticRouteSerializer(NetBoxModelSerializer):
             'devices',
             'vrf',
             'prefix',
+            'type',
             'next_hop',
+            'interface_next_hop',
             'name',
             'metric',
             'tag',
@@ -42,6 +44,7 @@ class StaticRouteSerializer(NetBoxModelSerializer):
             'display',
             'name',
             'prefix',
+            'type',
             'next_hop',
             'description',
         )

--- a/netbox_routing/choices/objects.py
+++ b/netbox_routing/choices/objects.py
@@ -20,3 +20,17 @@ class CommunityStatusChoices(ChoiceSet):
         (STATUS_RESERVED, 'Reserved', 'cyan'),
         (STATUS_DEPRECATED, 'Deprecated', 'red'),
     ]
+
+
+class StaticRouteTypeChoices(ChoiceSet):
+    key = 'StaticRoute.type'
+
+    TYPE_UNICAST     = 'unicast'
+    TYPE_BLACKHOLE   = 'blackhole'
+    TYPE_UNREACHABLE = 'unreachable'
+
+    CHOICES = [
+        (TYPE_UNICAST,     'Unicast',     'blue'),
+        (TYPE_BLACKHOLE,   'Blackhole',   'dark'),
+        (TYPE_UNREACHABLE, 'Unreachable', 'orange'),
+    ]

--- a/netbox_routing/migrations/0033_staticroute_type.py
+++ b/netbox_routing/migrations/0033_staticroute_type.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('netbox_routing', '0032_fix_eigrp_router_ordering'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='staticroute',
+            name='type',
+            field=models.CharField(
+                choices=[
+                    ('unicast', 'Unicast'),
+                    ('blackhole', 'Blackhole'),
+                    ('unreachable', 'Unreachable'),
+                ],
+                default='unicast',
+                max_length=20,
+                verbose_name='Type',
+            ),
+        ),
+    ]

--- a/netbox_routing/models/static.py
+++ b/netbox_routing/models/static.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 
 from ipam.fields import IPNetworkField
 from netbox.models import PrimaryModel
+from netbox_routing.choices.objects import StaticRouteTypeChoices
 from netbox_routing.fields.ip import IPAddressField
 
 __all__ = ('StaticRoute',)
@@ -23,6 +24,12 @@ class StaticRoute(PrimaryModel):
     )
     prefix = IPNetworkField(
         help_text=_('IPv4 or IPv6 network with mask'),
+    )
+    type = models.CharField(
+        max_length=20,
+        choices=StaticRouteTypeChoices,
+        default=StaticRouteTypeChoices.TYPE_UNICAST,
+        verbose_name=_('Type'),
     )
     next_hop = IPAddressField(
         verbose_name=_('Next Hop'),
@@ -64,6 +71,7 @@ class StaticRoute(PrimaryModel):
         'name',
         'devices',
         'prefix',
+        'type',
         'next_hop',
         'vrf',
         'metric',
@@ -82,18 +90,17 @@ class StaticRoute(PrimaryModel):
         )
 
     def __str__(self):
-        name = [
-            f'{self.prefix}',
-        ]
+        name = [f'{self.prefix}']
         if self.vrf:
-            name.append('VRF')
-            name.append(f'{self.vrf}')
+            name += ['VRF', f'{self.vrf}']
         if self.next_hop or self.interface_next_hop:
             name.append('via')
             if self.next_hop:
                 name.append(f'{self.next_hop}')
             if self.interface_next_hop:
                 name.append(f'{self.interface_next_hop}')
+        elif self.type != StaticRouteTypeChoices.TYPE_UNICAST:
+            name.append(f'[{self.get_type_display()}]')
         return ' '.join(name)
 
     def get_absolute_url(self):
@@ -101,11 +108,12 @@ class StaticRoute(PrimaryModel):
 
     def clean(self):
         super().clean()
-        if not self.interface_next_hop and not self.next_hop:
-            raise ValidationError(
-                {
-                    "next_hop": _(
-                        "A route requires set either an IP next hop or an Interface next hop."
-                    )
-                }
-            )
+        if self.type == StaticRouteTypeChoices.TYPE_UNICAST:
+            if not self.interface_next_hop and not self.next_hop:
+                raise ValidationError(
+                    {
+                        "next_hop": _(
+                            "A unicast route requires either an IP next hop or an Interface next hop."
+                        )
+                    }
+                )


### PR DESCRIPTION
## Problem

Static routes of type *blackhole/unreachable* (Juniper \`discard\`/\`reject\`, Linux/FRR \`blackhole\`/\`unreachable\`, Nokia SR-OS \`blackhole\`) have no next-hop address by definition. The current \`clean()\` validation rejects any route where both \`next_hop\` and \`interface_next_hop\` are null, making these route types impossible to represent in NetBox.

## Solution

Add a \`type\` field with choices \`unicast\` (default), \`blackhole\`, and \`unreachable\`. The \`clean()\` constraint is relaxed to only require a next-hop for unicast routes.

| Vendor | Blackhole | Unreachable (ICMP) |
|--------|-----------|-------------------|
| Juniper JunOS | \`discard\` | \`reject\` |
| Linux / FRR / BIRD | \`blackhole\` | \`unreachable\` |
| Nokia SR-OS | \`blackhole\` | — |

> **Note:** Cisco \`Null0\` routes already work today via \`interface_next_hop\` and are unaffected by this change.

## Changes

- `netbox_routing/choices/objects.py` — add `StaticRouteTypeChoices`
- `netbox_routing/models/static.py` — add `type` field, relax `clean()`, update `__str__()`
- `netbox_routing/api/_serializers/static.py` — expose `type` in fields, mark `next_hop` as optional
- `netbox_routing/migrations/0033_staticroute_type.py` — migration (default: `unicast`, no data loss for existing rows)