### PR TITLE
Closes #208, wrong API serializers

### DIFF
--- a/netbox_routing/api/_serializers/bgp.py
+++ b/netbox_routing/api/_serializers/bgp.py
@@ -173,10 +173,10 @@ class BGPRouterSerializer(NetBoxModelSerializer):
     asn = ASNSerializer(nested=True)
     settings = BGPSettingSerializer(many=True, required=False)
     tenant = TenantSerializer(nested=True, required=False)
-    peer_templates = BGPSessionTemplateSerializer(
+    peer_templates = BGPPeerTemplateSerializer(
         many=True, nested=True, required=False
     )
-    policy_templates = BGPSessionTemplateSerializer(
+    policy_templates = BGPPolicyTemplateSerializer(
         many=True, nested=True, required=False
     )
     session_templates = BGPSessionTemplateSerializer(


### PR DESCRIPTION
BGP Peer and Policy templates were using BGP session template serializers, changed them to correct ones.