### PR TITLE
Add 'flow_control' to API serializer with test Closes #212

### DIFF
--- a/netbox_routing/api/_serializers/objects.py
+++ b/netbox_routing/api/_serializers/objects.py
@@ -200,6 +200,7 @@ class RouteMapEntrySerializer(NetBoxModelSerializer):
             'route_map',
             'sequence',
             'action',
+            'flow_control',
             'match_prefix_list',
             'match_community_list',
             'match_community',

--- a/netbox_routing/tests/objects/test_api.py
+++ b/netbox_routing/tests/objects/test_api.py
@@ -324,6 +324,7 @@ class RouteMapEntryTestCase(APIViewTestCases.APIViewTestCase):
                 'route_map': cls.route_map[0].pk,
                 'action': 'permit',
                 'sequence': 3,
+                'flow_control': 4,
                 'match': {'tags': 4},
             },
             {


### PR DESCRIPTION
Closes #212
As noted in #212, the GraphQL isn't affected like I originally thought. This PR addresses *only* the REST API.

M: Expose 'flow_control' in API 
M: Added 'flow_control' to generic API test

- Verified live three ways against the running dev instance: GET now returns flow_control, PATCH now accepts and persists it, and the full RouteMapEntryTestCase suite (23 tests) passes.