### PR TITLE
Fix wrong view_name on several serializers' url field [Closes #218]

### DIFF
--- a/netbox_routing/api/_serializers/bgp.py
+++ b/netbox_routing/api/_serializers/bgp.py
@@ -69,7 +69,7 @@ class BGPSettingSerializer(NetBoxModelSerializer):
 
 class BGPSessionTemplateSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_routing-api:bgpscope-detail'
+        view_name='plugins-api:netbox_routing-api:bgpsessiontemplate-detail'
     )
 
     remote_as = ASNSerializer(nested=True, required=False)
@@ -105,7 +105,7 @@ class BGPSessionTemplateSerializer(NetBoxModelSerializer):
 
 class BGPPolicyTemplateSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_routing-api:bgpscope-detail'
+        view_name='plugins-api:netbox_routing-api:bgppolicytemplate-detail'
     )
 
     tenant = TenantSerializer(nested=True, required=False)
@@ -136,7 +136,7 @@ class BGPPolicyTemplateSerializer(NetBoxModelSerializer):
 
 class BGPPeerTemplateSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_routing-api:bgpaddressfamily-detail'
+        view_name='plugins-api:netbox_routing-api:bgppeertemplate-detail'
     )
 
     remote_as = ASNSerializer(nested=True, required=False)

--- a/netbox_routing/api/_serializers/objects.py
+++ b/netbox_routing/api/_serializers/objects.py
@@ -163,7 +163,7 @@ class CustomPrefixSerializer(NetBoxModelSerializer):
 
 class RouteMapSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_routing-api:prefixlist-detail'
+        view_name='plugins-api:netbox_routing-api:routemap-detail'
     )
 
     class Meta:
@@ -181,7 +181,7 @@ class RouteMapSerializer(NetBoxModelSerializer):
 
 class RouteMapEntrySerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_routing-api:prefixlistentry-detail'
+        view_name='plugins-api:netbox_routing-api:routemapentry-detail'
     )
     route_map = RouteMapSerializer(nested=True)
     match_prefix_list = PrefixListSerializer(nested=True, many=True, required=False)

--- a/netbox_routing/api/_serializers/ospf.py
+++ b/netbox_routing/api/_serializers/ospf.py
@@ -74,7 +74,7 @@ class OSPFAreaSerializer(NetBoxModelSerializer):
 
 class OSPFInterfaceSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(
-        view_name='plugins-api:netbox_routing-api:ospfarea-detail'
+        view_name='plugins-api:netbox_routing-api:ospfinterface-detail'
     )
     instance = OSPFInstanceSerializer(nested=True)
     area = OSPFAreaSerializer(nested=True)


### PR DESCRIPTION
Several serializers' url HyperlinkedIdentityField pointed at a different model's detail view instead of their own, so the self-referential url returned by the API pointed to the wrong resource entirely:

- BGPSessionTemplateSerializer  -> bgpscope-detail
- BGPPolicyTemplateSerializer   -> bgpscope-detail
- BGPPeerTemplateSerializer     -> bgpaddressfamily-detail
- RouteMapSerializer            -> prefixlist-detail
- RouteMapEntrySerializer       -> prefixlistentry-detail
- OSPFInterfaceSerializer       -> ospfarea-detail

All six now point at their own model's registered detail view (matching the router.register() basename in api/urls.py).

This was flagged as one item in the grab-bag report #199, which was closed as not_planned since it bundled several unrelated requests.

Closes #218